### PR TITLE
Fix annotation issue with babylon 6.10

### DIFF
--- a/ViewPager.js
+++ b/ViewPager.js
@@ -227,7 +227,7 @@ var ViewPager = React.createClass({
     }
   },
 
-  _getPage(pageIdx: number, loop = false: boolean) {
+  _getPage(pageIdx: number, loop : boolean = false) {
     var dataSource = this.props.dataSource;
     var pageID = dataSource.pageIdentities[pageIdx];
     return (


### PR DESCRIPTION
With latest babylon (6.10.0) installed the package will throw an error: 

node_modules/react-native-viewpager-es6/ViewPager.js: Type annotations must come before default assignments, e.g. instead of `age = 25: number` use `age: number = 25`.

And here’s the fix.
